### PR TITLE
Rewrite s3-asset-uploader using modern Node best-practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const options = {
   path: './public',
   ignorePaths: ['js/vendor', '.DS_Store'],
   prefix: 'assets',
-  digestFileName: 'config/asset-map.json'
+  digestFileKey: 'config/asset-map.json'
 }
 
 const s3SyncUploader = new S3Sync(config, options)

--- a/README.md
+++ b/README.md
@@ -2,26 +2,56 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/mix/s3-asset-uploader.svg)](https://greenkeeper.io/)
 
-for putting assets on s3
+Synchronizes a local directory with an Amazon S3 bucket
 
-``` js
+### Options
+
+Key | Type | Description
+--- | ---- | -----------
+`path` (**REQUIRED**) | `string` | the base path to synchronize with S3
+`ignorePaths` | `Array.<(RegExp\|string)>` | skip these paths when gathering files
+`digestFileKey` | `AWS.S3.ObjectKey` | the destination key of the generated digest file
+`prefix` | `string` | prepended to file names **(but not `digestFileKey`!)** when uploaded
+`headers` | `S3UploadHeaders` | extra params used by `AWS.S3` upload method
+`gzipHeaders` | `S3UploadHeaders` | extra params used by `AWS.S3` upload method for GZIP files
+`noUpload` | `boolean` | don't upload anything, just generate a digest mapping
+`noUploadDigestFile` | `boolean` | don't upload the digest mapping file
+`noUploadOriginalFiles` | `boolean` | don't upload the original (unhashed) files
+`noUploadHashedFiles` | `boolean` | don't upload the hashed files
+
+### Example usage
+
+```javascript
 const { S3Sync } = require('s3-asset-uploader')
 
 const config =  {
-  "key": "<key>",
-  "secret": "<secret>",
-  "bucket": "<s3-bucket-name>"
+  key: '<aws-access-key-id>',
+  secret: '<aws-secret-access-key>',
+  bucket: '<aws-s3-bucket-name>'
 }
 const options = {
   path: './public',
-  ignorePaths: ['public/js/vendor'],
-  prefix: '/assets',
-  digestFileName: 'config/asset-map.json',
-  digestOnly: false
+  ignorePaths: ['js/vendor', '.DS_Store'],
+  prefix: 'assets',
+  digestFileName: 'config/asset-map.json'
 }
 
-const sync = new S3Sync(config, options)
-sync.run().then(digest => {
-  console.log('Synchronized with S3! Digest: ', digest)
+const s3SyncUploader = new S3Sync(config, options)
+s3SyncUploader.run()
+.then(digest => {
+  console.log('S3 Sync complete! Digest: ', digest)
+})
+.catch(err => {
+  console.error('S3 Sync failed: ', err)
 })
 ```
+
+### Debug logging
+
+To see what's going on under the hood, add `s3-asset-uploader` to your `DEBUG` environment variable:
+
+```sh
+DEBUG=s3-asset-uploader
+```
+
+For more information on configuring the `debug` logger, see: https://github.com/visionmedia/debug#readme

--- a/README.md
+++ b/README.md
@@ -5,21 +5,23 @@
 for putting assets on s3
 
 ``` js
-var Sync = require('s3-asset-uploader').S3sync
-var config =  {
-    "key": "<key>"
-  , "secret": "<secret>"
-  , "bucket": "<bucket-name>"
-  , "cloudfront": "<cf-domain>"
+const { S3Sync } = require('s3-asset-uploader')
+
+const config =  {
+  "key": "<key>",
+  "secret": "<secret>",
+  "bucket": "<s3-bucket-name>"
+}
+const options = {
+  path: './public',
+  ignorePaths: ['public/js/vendor'],
+  prefix: '/assets',
+  digestFileName: 'config/asset-map.json',
+  digestOnly: false
 }
 
-new Sync(config, {
-    path: './public'
-  , prefix: '/assets'
-  , ignorePath: './public/js/vendor'
-  , digest: 'config/asset-map.json'
-  , complete: function () {
-      console.log('done')
-    }
+const sync = new S3Sync(config, options)
+sync.run().then(digest => {
+  console.log('Synchronized with S3! Digest: ', digest)
 })
 ```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const transformLib = require('./lib/transform')
 const FILE_EXTENSION_REGEXP = /((\.\w+)?\.\w+)$/
 const DEFAULT_ACL = 'public-read'
 const DEFAULT_DIGEST_FILE_NAME = 'asset-map.json'
-const DEFAULT_GZIP_CACHE_CONTROL = 'max-age=1314000'
+const DEFAULT_GZIP_CACHE_CONTROL = `max-age=${365*24*60*60}` // 1 year (in seconds)
 const DEFAULT_GZIP_HEADERS = {
   'ContentEncoding': 'gzip',
   'CacheControl': DEFAULT_GZIP_CACHE_CONTROL

--- a/index.js
+++ b/index.js
@@ -1,236 +1,349 @@
+/**
+ * Top-level s3-asset-uploader module
+ * @module s3-asset-uploader
+ * @see README.md
+ */
+
+// Node imports
 const fs = require('fs')
-const crypto = require('crypto')
 const path = require('path')
-const finder = require('findit')
-const debug = require('debug')('mix:s3')
-const Promise = require('bluebird')
+// NPM imports
+const debug = require('debug')('s3-asset-uploader')
 const AWS = require('aws-sdk')
-const mime = require('mime')
+const Bluebird = require('bluebird')
+// Lib imports
+const directoryLib = require('./lib/directory')
+const fileLib = require('./lib/file')
+const hashLib = require('./lib/hash')
+const transformLib = require('./lib/transform')
 
-const DEFAULT_HEADERS = {
-  'ACL': 'public-read'
-}
-const TYPES = {
-  'js': 'utf8',
-  'css': 'utf8',
-  'sass': 'utf8',
-  'scss': 'utf8',
-  'png': 'binary',
-  'jpg': 'binary',
-  'jpeg': 'binary',
-  'gif': 'binary',
-  'ico': 'binary'
+const FILE_EXTENSION_REGEXP = /((\.\w+)?\.\w+)$/
+const DEFAULT_ACL = 'public-read'
+const DEFAULT_DIGEST_FILE_NAME = 'asset-map.json'
+const DEFAULT_GZIP_CACHE_CONTROL = 'max-age=1314000'
+const DEFAULT_GZIP_HEADERS = {
+  'ContentEncoding': 'gzip',
+  'CacheControl': DEFAULT_GZIP_CACHE_CONTROL
 }
 
+/**
+ * The configuration Object passed into the `S3Sync` constructor
+ * @typedef {Object} S3SyncConfig
+ * @property {string} key - your AWS access key ID
+ * @property {string} secret - your AWS secret access key
+ * @property {AWS.S3.BucketName} bucket - the name of the destination AWS S3 bucket
+ */
+
+/**
+ * The options Object passed into the `S3Sync` constructor
+ * @typedef {Object} S3SyncOptions
+ * @property {string} path - the base path to synchronize with S3
+ * @property {Array.<(RegExp|string)>} [ignorePaths] - do not synchronize these paths with S3
+ * @property {string} [prefix] - prepended to all destination file names when uploaded
+ * @property {AWS.S3.ObjectKey} [digestFileName] - the destination file name of the generated digest file
+ * @property {boolean} [digestOnly] - upload only the generated digest file
+ * @property {boolean} [dryRun] - don't upload anything, just log what would have been uploaded
+ * @property {S3UploadHeaders} [headers] - params used by AWS.S3 upload method
+ * @property {S3UploadHeaders} [gzipHeaders] - params used by AWS.S3 upload method for GZIP files
+ */
+
+/** @typedef {string} AbsoluteFilePath */
+/** @typedef {string} RelativeFileName */
+/** @typedef {AWS.S3.ObjectKey} HashedS3Key */
+/** @typedef {Object.<RelativeFileName,HashedS3Key>} S3SyncDigest */
+/** @typedef {AWS.S3.PutObjectRequest} S3UploadParams */
+/** @typedef {(AWS.S3.CompleteMultipartUploadOutput|void)} S3UploadResult */
+
+/**
+ * Some (but not all) of the parameters needed for `S3UploadParams`
+ * @typedef {Object} S3UploadHeaders
+ * @property {AWS.S3.ObjectCannedACL} ACL
+ * @property {AWS.S3.BucketName} Bucket
+ * @property {AWS.S3.CacheControl} [CacheControl]
+ * @property {AWS.S3.ContentType} ContentType
+ * @property {AWS.S3.ContentEncoding} [ContentEncoding]
+ */
+
+/**
+ * Class representing an operation to synchronize a directory with an Amazon S3 bucket
+ */
 class S3Sync {
-  constructor (config, options) {
-    this.options = options
-    AWS.config.accessKeyId = config.key
-    AWS.config.secretKeyId = config.secret
-    this.client = new AWS.S3()
+  /**
+   * @param {S3SyncConfig} config
+   * @param {S3SyncOptions} options
+   * @constructor
+   */
+  constructor(config, options) {
+    this.client = new AWS.S3({
+      accessKeyId: config.key,
+      secretAccessKey: config.secret
+    })
     this.bucket = config.bucket
-    this.path = options.path
+    this.path = fs.realpathSync(options.path)
+    this.ignorePaths = options.ignorePaths || []
+    this.digestFileName = options.digestFileName || DEFAULT_DIGEST_FILE_NAME
+    this.digestOnly = options.digestOnly || false
+    this.dryRun = options.dryRun || false
     this.prefix = options.prefix || ''
-    this.digest = options.digest
-    this._inProgress = false
-    this._files = []
-    this._digest = {}
-    this._timer
+    this.headers = options.headers || {}
+    this.gzipHeaders = options.gzipHeaders || DEFAULT_GZIP_HEADERS
+    this.reset()
   }
 
-  static md5(text) {
-    return crypto
-    .createHash('md5')
-    .update(text)
-    .digest('hex')
+  /**
+   * The main work-horse method that performs all of the sub-tasks to synchronize
+   * @returns {Bluebird<S3SyncDigest>}
+   * @public
+   */
+  run() {
+    return this.gatherFiles()
+    .then(() => this.addFilesToDigest())
+    .then(() => this.syncFiles())
+    .then(() => this.uploadDigest())
+    .then(() => this.digest)
+    .finally(() => this.reset())
   }
 
-  init() {
-    this.finder(this.path)
-    .on('file', this.addFile.bind(this))
-    .on('end', this.start.bind(this))
+  /**
+   * Resets the `S3Sync` instance back to its initial state
+   * @returns {void}
+   * @private
+   */
+  reset() {
+    /** @type {Array.<AbsoluteFilePath>} */
+    this.gatheredFilePaths = []
+    /** @type {Object.<AbsoluteFilePath,AWS.S3.ETag>} */
+    this.filePathToEtagMap = {}
+    /** @type {S3SyncDigest} */
+    this.digest = {}
   }
 
-  getSettings() {
-    return Object.assign({}, this.options.headers || {}, DEFAULT_HEADERS)
+  /**
+   * Walks the `this.path` directory and collects all of the file paths
+   * @returns {Bluebird<void>}
+   * @private
+   */
+  gatherFiles() {
+    return directoryLib.getFileNames(this.path, this.ignorePaths)
+    .then(filePaths => {
+      this.gatheredFilePaths.push(...filePaths)
+    })
   }
 
-  finder(path) {
-    return finder(path)
+  /**
+   * Iterates through the gathered files and generates the hashed digest mapping
+   * @returns {Bluebird<void>}
+   * @private
+   */
+  addFilesToDigest() {
+    return Bluebird.mapSeries(this.gatheredFilePaths, filePath => {
+      return this.addFileToDigest(filePath)
+    })
+    .then(() => {}) // Normalize fulfilled value to void/undefined
   }
 
-  addFile(file) {
-    if (!this.options.ignorePath) {
-      this._files.push(file)
-    } else if (!(new RegExp('^' + this.options.ignorePath).test(path.dirname(file)))) {
-      this._files.push(file)
+  /**
+   * Uploads the gathered files
+   * @returns {Bluebird<void>}
+   * @private
+   */
+  syncFiles() {
+    if (this.digestOnly) {
+      return Bluebird.resolve()
     }
+    return Bluebird.mapSeries(this.gatheredFilePaths, filePath => {
+      return this.uploadOriginalFile(filePath)
+      .then(() => this.uploadHashedFile(filePath))
+    })
+    .then(() => {}) // Normalize fulfilled value to void/undefined
   }
 
-  start() {
-    if (!this._files.length) {
-      this.writeDigestFile((err, resp) => {
-        if (err) {
-          debug('error writing digest file', err)
-        } else {
-          debug('wrote digest file', resp)
-        }
-        this.options.complete && this.options.complete(err)
-      })
-    } else if (this._inProgress) {
-      this._timer = setTimeout(this.start.bind(this), 50)
-    } else {
-      if (this.options.digestOnly) {
-        addToDigest.call(this, this._files.pop())
-        this.start()
-      } else {
-        this._inProgress = true
-        this.put(this._files.pop(), this.handlePutResponse.bind(this))
-      }
-    }
+  /**
+   * Hashes the file and adds it to the digest
+   * @param {AbsoluteFilePath} filePath
+   * @returns {Bluebird<void>}
+   * @private
+   */
+  addFileToDigest(filePath) {
+    return hashLib.hashFromFile(filePath)
+    .then(hash => {
+      const originalFileName = this.relativeFileName(filePath)
+      const hashedFileName = this.hashedFileName(originalFileName, hash)
+      this.filePathToEtagMap[filePath] = hash
+      this.digest[originalFileName] = hashedFileName
+    })
   }
 
-  writeDigestFile(callback) {
-    const headers = Object.assign({}, this.getSettings(), mergeHeaders(this.digest))
-
-    this.client.upload(Object.assign({
-      Body: JSON.stringify(this.getDigest()),
-      Bucket: this.bucket,
-      Key: this.digest
-    }, headers))
-    .send(callback)
+  /**
+   * @returns {Bluebird<S3UploadResult>}
+   * @private
+   */
+  uploadDigest() {
+    debug('Uploading digest file', this.digestFileName)
+    return this.upload({
+      'ACL': DEFAULT_ACL,
+      'Body': JSON.stringify(this.digest),
+      'Bucket': this.bucket,
+      'ContentType': 'application/json',
+      'Key': this.digestFileName
+    })
   }
 
-  readFileContents(file) {
-    return fs.readFileSync(file, TYPES[file.split('.').pop()])
-  }
-
-  hashContents(file) {
-    const contents = this.readFileContents(file)
-    const up = file.substring(this.path.length)
-    const hash = S3Sync.md5(contents)
-    return up.replace(/(\.\w+)$/, '-' + hash + '$1')
-  }
-
-  put(file, done) {
-    addToDigest.call(this, file)
-
-    const s3FileName = file.substring(this.path.length)
-    const s3FileNameWithPrefix = this.prefix + s3FileName
-    const md5File = this._digest[s3FileName]
-
-    debug('putting original file %s at destination %s', file, s3FileNameWithPrefix)
-
-    const body =  fs.createReadStream(file)
-    const headers = Object.assign({}, this.getSettings(), mergeHeaders(file))
-
-    this.client.upload(Object.assign({
-      Body: body,
-      Bucket: this.bucket,
-      Key: s3FileNameWithPrefix
-    }, headers))
-    .send(err => {
-      if (err) {
-        done(err)
-      } else {
-        this.md5PreCheck(file, md5File, done)
+  /**
+   * @param {AbsoluteFilePath} filePath
+   * @returns {Bluebird<S3UploadResult>}
+   * @private
+   */
+  uploadOriginalFile(filePath) {
+    const originalFileName = this.relativeFileName(filePath)
+    const key = this.s3KeyForRelativeFileName(originalFileName)
+    const etag = this.filePathToEtagMap[filePath]
+    return this.shouldUpload(key, etag)
+    .then(shouldUpload => {
+      if (shouldUpload) {
+        const headers = this.fileHeaders(filePath)
+        const params = Object.assign({}, headers, {
+          'Key': key,
+          'Body': fs.createReadStream(filePath)
+        })
+        debug('Uploading original file: ', key)
+        return this.upload(params)
       }
     })
   }
 
-  md5PreCheck(file, md5File, done) {
-    this.s3FilePreCheck(md5File)
-    .then(() => {
-      debug('putting new file', md5File)
-      const md5body =  fs.createReadStream(file)
-      const md5headers = Object.assign({}, this.getSettings(), mergeHeaders(md5File))
-      this.client.upload(Object.assign({
-        Body: md5body,
-        Bucket: this.bucket,
-        Key: md5File
-      }, md5headers))
-      .send(err => {
-        if (err) {
-          done(err)
-        } else{
-          done()
+  /**
+   * @param {AbsoluteFilePath} filePath
+   * @returns {Bluebird<S3UploadResult>}
+   * @private
+   */
+  uploadHashedFile(filePath) {
+    const originalFileName = this.relativeFileName(filePath)
+    const key = this.digest[originalFileName]
+    if (!key) {
+      // This should never happen under normal circumstances!
+      debug('Missing hash for original file: ', originalFileName)
+      return Bluebird.resolve()
+    }
+    return transformLib.replaceHashedFilenames({
+      filePath,
+      relativeFileName: originalFileName,
+      digest: this.digest
+    })
+    .then(({ transformed, stream, hash }) => {
+      const etag = transformed ? hash : this.filePathToEtagMap[filePath]
+      return this.shouldUpload(key, etag)
+      .then(shouldUpload => {
+        if (shouldUpload) {
+          const headers = this.fileHeaders(filePath)
+          const params = Object.assign({}, headers, {
+            'Key': key,
+            'Body': stream
+          })
+          debug('Uploading hashed file: ', key)
+          return this.upload(params)
         }
       })
+    })
+  }
+
+  /**
+   * @param {S3UploadParams} params
+   * @returns {Bluebird<S3UploadResult>}
+   * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property
+   * @private
+   */
+  upload(params) {
+    if (this.dryRun) {
+      debug('[DRY-RUN] NOT uploading', params['Key'])
+      return Bluebird.resolve()
+    }
+    return Bluebird.fromCallback(callback => {
+      this.client.upload(params, callback)
+    })
+  }
+
+  /**
+   * @param {AWS.S3.ObjectKey} key
+   * @param {AWS.S3.ETag} etag
+   * @returns {Bluebird<boolean>}
+   * @private
+   */
+  shouldUpload(key, etag) {
+    return Bluebird.fromCallback(callback => {
+      this.client.headObject({
+        'Bucket': this.bucket,
+        'Key': key,
+        'IfNoneMatch': etag
+      }, callback)
+    })
+    .then(() => {
+      // File found, ETag does not match
+      return true
     })
     .catch(err => {
-      if (/already exists/i.test(err.message)) {
-        done()
-      } else {
-        done(err)
+      switch (err.name) {
+        case 'NotFound': return true
+        case 'NotModified': return false
+        default: throw err
       }
     })
   }
 
-  s3FilePreCheck(file) {
-    // check for existence of file and reject if it exists to avoid uploading same file again
-    return new Promise((resolve, reject) => {
-      this.client.getObject({
-        Bucket: this.bucket,
-        Key: file
-      }, function (err) {
-        if (this.httpResponse.statusCode == 404) {
-          resolve()
-        } else if (this.httpResponse.statusCode == 200) {
-          reject(new Error('File already exists - ' + file))
-        } else {
-          reject(
-            new Error('S3 File precheck failed [' + this.httpResponse.statusCode + '] for ' +
-              file + ': ' + err.message)
-          )
-        }
-      })
-    })
+  /**
+   * @param {AbsoluteFilePath} filePath
+   * @returns {RelativeFileName}
+   * @private
+   */
+  relativeFileName(filePath) {
+    return filePath.substring(this.path.length + path.sep.length)
   }
 
-  abort(e) {
-    this._timer && clearTimeout(this._timer)
-    debug('S3 sync aborted', e)
-    this.options.complete && this.options.complete(new Error('Sync aborted'))
+  /**
+   * @param {RelativeFileName} fileName
+   * @returns {AWS.S3.ObjectKey}
+   * @private
+   */
+  s3KeyForRelativeFileName(fileName) {
+    return path.posix.join(this.prefix, fileName)
   }
 
-  getDigest() {
-    return this._digest
+  /**
+   * @param {RelativeFileName} fileName
+   * @param {AWS.S3.ETag} hash
+   * @returns {HashedS3Key}
+   * @private
+   */
+  hashedFileName(fileName, hash) {
+    return this.s3KeyForRelativeFileName(fileName)
+    .replace(FILE_EXTENSION_REGEXP, `-${hash}$1`)
   }
 
-  handlePutResponse(error) {
-    if (error) {
-      this.options.error && this.options.error(error)
-      this.abort(error)
-    } else {
-      this._inProgress = false
-      this.start()
+  /**
+   * @param {AbsoluteFilePath} filePath
+   * @returns {S3UploadHeaders}
+   * @private
+   */
+  fileHeaders(filePath) {
+    const defaultHeaders = {
+      'ACL': DEFAULT_ACL,
+      'Bucket': this.bucket
     }
+    const fileHeaders = {
+      'ContentType': fileLib.getContentType(filePath)
+    }
+    const gzipHeaders = fileLib.isGzipped(filePath)
+    ? this.gzipHeaders
+    : {}
+    return Object.assign(
+      defaultHeaders,
+      this.headers,
+      fileHeaders,
+      gzipHeaders
+    )
   }
 }
 
 module.exports = {
   S3Sync
-}
-
-function mergeHeaders(file) {
-  const o = {}
-  if (file.match('.gz')) {
-    o['ContentEncoding'] = 'gzip'
-    o['CacheControl'] = 'max-age=1314000'
-  }
-  o['ContentType'] = mime.getType(file)
-  // overwrite `gz` headers
-  if (file.match('.js')) {
-    o['ContentType'] = 'application/javascript'
-  }
-  if (file.match('.css')) {
-    o['ContentType'] = 'text/css'
-  }
-  return o
-}
-
-function addToDigest(file) {
-  const md5File = this.prefix + this.hashContents(file)
-  const s3FileName = file.substring(this.path.length)
-  this._digest[s3FileName] = md5File
 }

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -1,0 +1,50 @@
+// Node imports
+const fs = require('fs')
+const path = require('path')
+// NPM imports
+const Bluebird = require('bluebird')
+
+/**
+ * @param {string} basePath
+ * @param {Array.<(RegExp|string)>} filters
+ * @returns {Bluebird<Array.<string>>} The full paths of all files in the directory
+ */
+function getFileNames(basePath, filters = []) {
+  return recurseDirectory(basePath)
+
+  /**
+   * @param {string} dirPath
+   * @returns {Bluebird<Array.<string>>} The full paths of all files in the directory
+   */
+  function recurseDirectory(dirPath) {
+    return Bluebird.fromCallback(callback => {
+      fs.readdir(dirPath, { withFileTypes: true }, callback)
+    })
+    .then(dirents => {
+      return Bluebird.map(dirents, dirent => {
+        const fullPath = path.resolve(dirPath, dirent.name)
+        if (isFiltered(fullPath)) {
+          return []
+        }
+        if (dirent.isDirectory()) {
+          return recurseDirectory(fullPath)
+        }
+        return [fullPath]
+      })
+    })
+    .then(filePaths => Array.prototype.concat(...filePaths))
+  }
+
+  /**
+   * @param {string} fullPath
+   * @returns {boolean}
+   */
+  function isFiltered(fullPath) {
+    const relativePath = path.relative(basePath, fullPath)
+    return filters.some(filter => !!relativePath.match(filter))
+  }
+}
+
+module.exports = {
+  getFileNames
+}

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,0 +1,47 @@
+// NPM imports
+const mime = require('mime')
+
+const EXTENSION_GZ_REGEXP = /\.gz$/
+const EXTENSION_JS_REGEXP = /\.js(\.gz)?$/
+const EXTENSION_CSS_REGEXP = /\.css(\.gz)?$/
+const EXTENSION_SOURCEMAP_REGEXP = /\.(js|css)\.map$/
+
+const CONTENT_TYPE_BINARY = 'application/octet-stream'
+const CONTENT_TYPE_CSS = 'text/css'
+const CONTENT_TYPE_JS = 'application/javascript'
+const CONTENT_TYPE_JSON = 'application/json'
+
+/**
+ * @param {string} filePath The absolute path to the file
+ * @returns {string} The MIME type of the file
+ */
+function getContentType(filePath) {
+  // Override gzip MIME type for web application artifacts
+  if (EXTENSION_JS_REGEXP.test(filePath)) {
+    return CONTENT_TYPE_JS
+  }
+  if (EXTENSION_CSS_REGEXP.test(filePath)) {
+    return CONTENT_TYPE_CSS
+  }
+  if (EXTENSION_SOURCEMAP_REGEXP.test(filePath)) {
+    return CONTENT_TYPE_JSON
+  }
+  return mime.getType(filePath) || CONTENT_TYPE_BINARY
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isGzipped(filePath) {
+  return EXTENSION_GZ_REGEXP.test(filePath)
+}
+
+module.exports = {
+  CONTENT_TYPE_BINARY,
+  CONTENT_TYPE_CSS,
+  CONTENT_TYPE_JS,
+  CONTENT_TYPE_JSON,
+  getContentType,
+  isGzipped
+}

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,0 +1,52 @@
+// Node imports
+const crypto = require('crypto')
+const fs = require('fs')
+// NPM imports
+const Bluebird = require('bluebird')
+
+const HASH_ALGORITHM = 'md5'
+const HASH_DIGEST_ENCODING = 'hex'
+
+/** @typedef {string} Hash */
+
+/**
+ * Generate a hash of the supplied file
+ * @param {string} filePath
+ * @returns {Bluebird<Hash>}
+ */
+function hashFromFile(filePath) {
+  return hashFromStream(fs.createReadStream(filePath))
+}
+
+/**
+ * Generate a hash of the supplied stream
+ * @param {NodeJS.ReadableStream} readableStream
+ * @returns {Bluebird<Hash>}
+ */
+function hashFromStream(readableStream) {
+  return new Bluebird((resolve, reject) => {
+    const hashStream = crypto.createHash(HASH_ALGORITHM)
+    readableStream.pipe(hashStream)
+    .on('error', reject)
+    .on('finish', () => {
+      resolve(hashStream.read().toString(HASH_DIGEST_ENCODING))
+    })
+  })
+}
+
+/**
+ * Generate a hash of the supplied string
+ * @param {string} data
+ * @returns {Hash}
+ */
+function hashFromString(data) {
+  return crypto.createHash(HASH_ALGORITHM)
+  .update(data)
+  .digest(HASH_DIGEST_ENCODING)
+}
+
+module.exports = {
+  hashFromFile,
+  hashFromStream,
+  hashFromString
+}

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,67 @@
+// Node imports
+const fs = require('fs')
+const stream = require('stream')
+const zlib = require('zlib')
+// NPM imports
+const Bluebird = require('bluebird')
+// Lib imports
+const fileLib = require('./file')
+
+/**
+ * @param {string} filePath
+ * @returns {Bluebird<string>}
+ * @private
+ */
+function fileToString(filePath) {
+  const fileStream = fs.createReadStream(filePath)
+  const readerStream = fileLib.isGzipped(filePath)
+  ? fileStream.pipe(zlib.createGunzip())
+  : fileStream
+  return streamToString(readerStream)
+}
+
+/**
+ * @param {NodeJS.ReadableStream} readerStream
+ * @param {BufferEncoding} [encoding]
+ * @returns {Bluebird<string>}
+ */
+function streamToString(readerStream, encoding = 'utf8') {
+  return new Bluebird((resolve, reject) => {
+    /** @type {Array.<Uint8Array>} */
+    const chunks = []
+    readerStream.on('data', (/** @type {Uint8Array} */ chunk) => {
+      chunks.push(chunk)
+    })
+    readerStream.on('error', reject)
+    readerStream.on('end', () => {
+      resolve(Buffer.concat(chunks).toString(encoding))
+    })
+  })
+}
+
+/**
+ * @param {string} data
+ * @param {BufferEncoding} [encoding]
+ * @returns {NodeJS.ReadableStream}
+ * @private
+ */
+function stringToStream(data, encoding = 'utf8') {
+  let cursor = 0
+  const buffer = Buffer.from(data, encoding)
+  return new stream.Readable({
+    read(size) {
+      if (cursor >= buffer.length) {
+        this.push(null)
+      } else {
+        this.push(buffer.slice(cursor, cursor + size))
+        cursor += size
+      }
+    }
+  })
+}
+
+module.exports = {
+  fileToString,
+  streamToString,
+  stringToStream
+}

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,0 +1,201 @@
+// Node imports
+const fs = require('fs')
+const path = require('path')
+const zlib = require('zlib')
+// NPM imports
+const Bluebird = require('bluebird')
+// Lib imports
+const fileLib = require('./file')
+const hashLib = require('./hash')
+const streamLib = require('./stream')
+
+const { CONTENT_TYPE_CSS, CONTENT_TYPE_JS } = fileLib
+
+const DEFAULT_GZIP_OPTIONS = { level: 9 }
+
+const CSS_URL_REGEXP = /url\(\/([^)]+)\)/g
+const CSS_SOURCEMAP_REGEXP = /\/\*# sourceMappingURL=([^*]+)\*\/$/
+const JS_SOURCEMAP_REGEXP = /\/\/# sourceMappingURL=(.+)$/
+
+/**
+ * The mapping of original file paths to hashed file names
+ * @typedef {Object.<string,string>} S3SyncDigest
+ * @see index.js `S3SyncDigest` type definition
+ */
+
+/**
+ * @typedef {Object} ReplaceHashedFilenamesOptions
+ * @property {string} filePath
+ * @property {string} relativeFileName
+ * @property {S3SyncDigest} digest
+ */
+
+/**
+ * @typedef {Object} ReplaceHashedFilenamesResult
+ * @property {boolean} transformed
+ * @property {NodeJS.ReadableStream} stream
+ * @property {string} [hash]
+ */
+
+/**
+ * @callback TransformFileCallback
+ * @param {string} fileData
+ * @return {string} transformed file data
+ */
+
+/**
+ * @param {ReplaceHashedFilenamesOptions} options
+ * @returns {Bluebird<ReplaceHashedFilenamesResult>}
+ * @public
+ */
+function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
+  const relativeDirPath = path.dirname(relativeFileName)
+  const contentType = fileLib.getContentType(filePath)
+  if (contentType === CONTENT_TYPE_JS) {
+    return transformFile(replaceHashedFilenamesInJs)
+  }
+  if (contentType === CONTENT_TYPE_CSS) {
+    return transformFile(replaceHashedFilenamesInCss)
+  }
+  return Bluebird.resolve(originalFileResult())
+
+  /**
+   * @returns {ReplaceHashedFilenamesResult}
+   */
+  function originalFileResult() {
+    return {
+      transformed: false,
+      stream: fs.createReadStream(filePath)
+    }
+  }
+
+  /**
+   * @param {string} transformedData
+   * @param {string} recalculatedHash
+   * @returns {ReplaceHashedFilenamesResult}
+   */
+  function transformedFileResult(transformedData, recalculatedHash) {
+    return {
+      transformed: true,
+      stream: transformedDataToStream(transformedData),
+      hash: recalculatedHash
+    }
+  }
+
+  /**
+   * @param {TransformFileCallback} transformCallback
+   * @returns {Bluebird<ReplaceHashedFilenamesResult>}
+   */
+  function transformFile(transformCallback) {
+    return streamLib.fileToString(filePath)
+    .then(originalData => {
+      const transformedData = transformCallback(originalData)
+      if (originalData === transformedData) {
+        return originalFileResult()
+      }
+      return recalculateHash(transformedData)
+      .then(recalculatedHash => {
+        return transformedFileResult(transformedData, recalculatedHash)
+      })
+    })
+  }
+
+  /**
+   * @param {string} transformedData
+   * @returns {NodeJS.ReadableStream}
+   */
+  function transformedDataToStream(transformedData) {
+    const transformedStream = streamLib.stringToStream(transformedData)
+    // Re-compress the stream if the original file was gzipped
+    return fileLib.isGzipped(filePath)
+    ? transformedStream.pipe(zlib.createGzip(DEFAULT_GZIP_OPTIONS))
+    : transformedStream
+  }
+
+  /**
+   * @param {string} transformedData
+   * @returns {Bluebird<string>} recalculated hash of transformed file
+   */
+  function recalculateHash(transformedData) {
+    if (!fileLib.isGzipped(filePath)) {
+      // Fast-path to avoid unnecessary conversion to stream
+      return Bluebird.resolve(hashLib.hashFromString(transformedData))
+    }
+    const transformedStream = transformedDataToStream(transformedData)
+    return hashLib.hashFromStream(transformedStream)
+  }
+
+  /**
+   * Replaces file names with their hashed versions in a CSS file
+   * @param {string} fileData
+   * @returns {string}
+   */
+  function replaceHashedFilenamesInCss(fileData) {
+    return fileData
+    .replace(CSS_URL_REGEXP, cssUrlReplacer)
+    .replace(CSS_SOURCEMAP_REGEXP, cssSourceMapReplacer)
+  }
+
+  /**
+   * Replaces file names with their hashed versions in a Javascript file
+   * @param {string} fileData
+   * @returns {string}
+   */
+  function replaceHashedFilenamesInJs(fileData) {
+    return fileData.replace(JS_SOURCEMAP_REGEXP, jsSourceMapReplacer)
+  }
+
+  /**
+   * Replaces relative URLs with the hashed version from the digest
+   * @param {string} match
+   * @param {string} absoluteUrl
+   * @returns {string}
+   */
+  function cssUrlReplacer(match, absoluteUrl) {
+    return digest[absoluteUrl]
+    ? `url(/${digest[absoluteUrl]})`
+    : match
+  }
+
+  /**
+   * Replaces the sourceMappingURL with the hashed version from the digest
+   * @param {string} match
+   * @param {string} fileBaseName
+   * @returns {string}
+   */
+  function cssSourceMapReplacer(match, fileBaseName) {
+    const sourceMappingUrl = hashedSourceMapFileBaseName(fileBaseName)
+    return sourceMappingUrl
+    ? `/*# sourceMappingURL=${sourceMappingUrl}*/`
+    : match
+  }
+
+  /**
+   * Replaces the sourceMappingURL with the hashed version from the digest
+   * @param {string} match
+   * @param {string} fileBaseName
+   * @returns {string}
+   */
+  function jsSourceMapReplacer(match, fileBaseName) {
+    const sourceMappingUrl = hashedSourceMapFileBaseName(fileBaseName)
+    return sourceMappingUrl
+    ? `//# sourceMappingURL=${sourceMappingUrl}`
+    : match
+  }
+
+  /**
+   * Looks up the hashed sourceMap file relative to the transformed file
+   * @param {string} fileBaseName
+   * @returns {(string|void)}
+   */
+  function hashedSourceMapFileBaseName(fileBaseName) {
+    const matchedFileName = path.join(relativeDirPath, fileBaseName)
+    if (digest[matchedFileName]) {
+      return path.basename(digest[matchedFileName])
+    }
+  }
+}
+
+module.exports = {
+  replaceHashedFilenames
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -995,6 +995,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "typescript": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-asset-uploader",
-  "version": "0.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,6 +24,30 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.25.tgz",
+      "integrity": "sha512-yfhIBix+AIFTmYGtkC0Bi+XGjSkOINykqKvO/Wqdz/DuXlAKK7HmhLAXdPIGsV4xzKcL3ev/zYc4yLNo+OvGaw==",
+      "dev": true
+    },
+    "@types/debug": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.31.tgz",
+      "integrity": "sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
@@ -37,9 +61,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -85,50 +109,19 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.4.7.tgz",
-      "integrity": "sha1-o45ORuYilRR5S6A7aG1rI7Ba698=",
+      "version": "2.382.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.382.0.tgz",
+      "integrity": "sha512-wGjZLYo2ZxGTlj2cHy/0zOfYJKUVBQYG1vpW4Cnbgo3HTtOu906a6tqkiD8QuN0EyEkn7i+wyjSiUFOCh3T/2g==",
       "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
         "jmespath": "0.15.0",
-        "sax": "1.1.5",
-        "xml2js": "0.4.15",
-        "xmlbuilder": "2.6.2"
-      },
-      "dependencies": {
-        "jmespath": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-          "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-        },
-        "sax": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
-          "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M="
-        },
-        "xml2js": {
-          "version": "0.4.15",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
-          "integrity": "sha1-lc0D/y3RROwovGJzvysokMWBrQw=",
-          "requires": {
-            "sax": ">=0.6.0",
-            "xmlbuilder": ">=2.4.6"
-          }
-        },
-        "xmlbuilder": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
-          "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
-          "requires": {
-            "lodash": "~3.5.0"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
-              "integrity": "sha1-Gbs/TVEnjwuMgY7RRcdOz5/kDm0="
-            }
-          }
-        }
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.19"
       }
     },
     "balanced-match": {
@@ -137,10 +130,15 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
     "bluebird": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.1.5.tgz",
-      "integrity": "sha1-aSeKHh02WhgXuojzIUwvlCd50K4="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -150,6 +148,16 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "caller-path": {
@@ -240,10 +248,9 @@
       }
     },
     "debug": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -270,9 +277,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
-      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.11.1.tgz",
+      "integrity": "sha512-gOKhM8JwlFOc2acbOrkYR05NW8M6DCMSvfcJiBB5NDxRE1gv8kbvxKaC9u69e6ZGEMWXcswA/7eKR229cEIpvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -284,7 +291,7 @@
         "eslint-scope": "^4.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "espree": "^5.0.0",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
@@ -294,7 +301,6 @@
         "ignore": "^4.0.6",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
         "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
@@ -338,9 +344,9 @@
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.2",
@@ -383,6 +389,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "external-editor": {
       "version": "3.0.3",
@@ -431,11 +442,6 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
-    },
-    "findit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
-      "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4="
     },
     "flat-cache": {
       "version": "1.3.4",
@@ -501,6 +507,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
       "version": "4.0.6",
@@ -580,17 +591,21 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -637,9 +652,9 @@
       "dev": true
     },
     "mime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -674,8 +689,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -770,16 +784,20 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.2.tgz",
-      "integrity": "sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -846,6 +864,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -886,7 +909,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -979,12 +1002,29 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
       }
     },
-    "valentine": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/valentine/-/valentine-2.1.4.tgz",
-      "integrity": "sha1-ucgRnA0m25OmbzvrpKgzx6VM9h8="
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "which": {
       "version": "1.3.1",
@@ -1015,6 +1055,20 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "s3-asset-uploader",
-  "version": "0.2.2",
-  "description": "aws s3 asset uploader",
+  "version": "2.0.0",
+  "description": "AWS S3 Asset Uploader",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/eslint ./"
@@ -15,20 +15,23 @@
     "aws",
     "uploader"
   ],
-  "author": "OpenLikes",
+  "author": "Mix Tech Inc.",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mix/s3-asset-uploader/issues"
   },
   "homepage": "https://github.com/mix/s3-asset-uploader",
   "dependencies": {
-    "aws-sdk": "^2.4.6",
-    "bluebird": "^3.1.5",
-    "findit": "~2.0.0",
-    "mime": "^2.3.1",
-    "valentine": "~2.1.0"
+    "aws-sdk": "^2.382.0",
+    "bluebird": "^3.5.3",
+    "debug": "^4.1.1",
+    "mime": "^2.4.0"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.25",
+    "@types/debug": "0.0.31",
+    "@types/mime": "^2.0.0",
+    "@types/node": "^10.12.18",
     "eslint": "^5.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "AWS S3 Asset Uploader",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/eslint ./"
+    "test": "npm run lint && npm run check-types",
+    "lint": "./node_modules/.bin/eslint .",
+    "check-types": "./node_modules/.bin/tsc"
   },
   "repository": {
     "type": "git",
@@ -32,6 +34,7 @@
     "@types/debug": "0.0.31",
     "@types/mime": "^2.0.0",
     "@types/node": "^10.12.18",
-    "eslint": "^5.9.0"
+    "eslint": "^5.9.0",
+    "typescript": "^3.2.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "target": "es6"
+  },
+  "include": [
+    "./index.js",
+    "./lib/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
This is effectively a complete rewrite which introduces **breaking API changes for existing consumers**, so I have bumped the major version number to `2.0.0`.

### Highlights include:
* Type checking with JSDoc
* Promise-based API
* Reduced dependencies
* Optimized upload pre-check by comparing ETag using `headObject` instead of `getObject`
* Hashed CSS/JS files are transformed so that URLs/sourceMaps point to hashed versions

## README Updates

### Options

Key | Type | Description
--- | ---- | -----------
`path` (**REQUIRED**) | `string` | the base path to synchronize with S3
`ignorePaths` | `Array.<(RegExp\|string)>` | skip these paths when gathering files
`digestFileKey` | `AWS.S3.ObjectKey` | the destination key of the generated digest file
`prefix` | `string` | prepended to file names **(but not `digestFileKey`!)** when uploaded
`headers` | `S3UploadHeaders` | extra params used by `AWS.S3` upload method
`gzipHeaders` | `S3UploadHeaders` | extra params used by `AWS.S3` upload method for GZIP files
`noUpload` | `boolean` | don't upload anything, just generate a digest mapping
`noUploadDigestFile` | `boolean` | don't upload the digest mapping file
`noUploadOriginalFiles` | `boolean` | don't upload the original (unhashed) files
`noUploadHashedFiles` | `boolean` | don't upload the hashed files

### Example usage

```javascript
const { S3Sync } = require('s3-asset-uploader')

const config =  {
  key: '<aws-access-key-id>',
  secret: '<aws-secret-access-key>',
  bucket: '<aws-s3-bucket-name>'
}
const options = {
  path: './public',
  ignorePaths: ['js/vendor', '.DS_Store'],
  prefix: 'assets',
  digestFileKey: 'config/asset-map.json'
}

const s3SyncUploader = new S3Sync(config, options)
s3SyncUploader.run()
.then(digest => {
  console.log('S3 Sync complete! Digest: ', digest)
})
.catch(err => {
  console.error('S3 Sync failed: ', err)
})
```

### Debug logging

To see what's going on under the hood, add `s3-asset-uploader` to your `DEBUG` environment variable:

```sh
DEBUG=s3-asset-uploader
```

For more information on configuring the `debug` logger, see: https://github.com/visionmedia/debug#readme
