### PR TITLE
Optionally respect hashes in original filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Key | Type | Description
 `noUploadDigestFile` | `boolean` | don't upload the digest mapping file
 `noUploadOriginalFiles` | `boolean` | don't upload the original (unhashed) files
 `noUploadHashedFiles` | `boolean` | don't upload the hashed files
+`hashedOriginalFileRegexp` | `RegExp | boolean` | respect hashes in original filenames; use this if your webpack output pattern includes `[chunkhash]`
+`includePseudoUnhashedOriginalFilesInDigest` | `boolean` | add pseudo-entries to the digest for the "unhashed" variant of hashed original files
 
 ### Example usage
 


### PR DESCRIPTION
https://app.asana.com/0/102902769366319/1159475072089888/f

Allows support for Lazy-loading Webpack hashed chunks