### PR TITLE
Support `gzipHashedFileKeyRegexp` option to compress hashed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Key | Type | Description
 `prefix` | `string` | prepended to file names **(but not `digestFileKey`!)** when uploaded
 `headers` | `S3UploadHeaders` | extra params used by `AWS.S3` upload method
 `gzipHeaders` | `S3UploadHeaders` | extra params used by `AWS.S3` upload method for GZIP files
+`gzipHashedFileKeyRegexp` | `RegExp` | gzip the hashed files that match this pattern
 `noUpload` | `boolean` | don't upload anything, just generate a digest mapping
 `noUploadDigestFile` | `boolean` | don't upload the digest mapping file
 `noUploadOriginalFiles` | `boolean` | don't upload the original (unhashed) files

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const Bluebird = require('bluebird')
 const directoryLib = require('./lib/directory')
 const fileLib = require('./lib/file')
 const hashLib = require('./lib/hash')
+const streamLib = require('./lib/stream')
 const transformLib = require('./lib/transform')
 
 const FILE_EXTENSION_REGEXP = /((\.\w+)?\.\w+)$/
@@ -282,7 +283,7 @@ class S3Sync {
     let fileStream = transformResult.stream
     let fileHeaders = this.fileHeaders(filePath)
     if (this.shouldGzipHashedFileKey(hashedFileKey)) {
-      fileStream = transformLib.gzipStream(fileStream)
+      fileStream = streamLib.gzipStream(fileStream)
       fileHeaders = { ...fileHeaders, ...this.gzipHeaders }
     }
     const etag = transformResult.hash || this.filePathToEtagMap[filePath]

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -6,33 +6,31 @@ const Bluebird = require('bluebird')
 
 /**
  * @param {string} basePath
- * @param {Array.<(RegExp|string)>} filters
- * @returns {Bluebird<Array.<string>>} The full paths of all files in the directory
+ * @param {(RegExp|string)[]} filters
+ * @returns {Promise.<string[]>} The full paths of all files in the directory
  */
-function getFileNames(basePath, filters = []) {
+async function getFileNames(basePath, filters = []) {
   return recurseDirectory(basePath)
 
   /**
    * @param {string} dirPath
-   * @returns {Bluebird<Array.<string>>} The full paths of all files in the directory
+   * @returns {Promise.<string[]>} The full paths of all files in the directory
    */
-  function recurseDirectory(dirPath) {
-    return Bluebird.fromCallback(callback => {
+  async function recurseDirectory(dirPath) {
+    const dirents = await Bluebird.fromCallback(callback => {
       fs.readdir(dirPath, { withFileTypes: true }, callback)
     })
-    .then(dirents => {
-      return Bluebird.map(dirents, dirent => {
-        const fullPath = path.resolve(dirPath, dirent.name)
-        if (isFiltered(fullPath)) {
-          return []
-        }
-        if (dirent.isDirectory()) {
-          return recurseDirectory(fullPath)
-        }
-        return [fullPath]
-      })
+    const filePaths = await Bluebird.map(dirents, dirent => {
+      const fullPath = path.resolve(dirPath, dirent.name)
+      if (isFiltered(fullPath)) {
+        return []
+      }
+      if (dirent.isDirectory()) {
+        return recurseDirectory(fullPath)
+      }
+      return [fullPath]
     })
-    .then(filePaths => Array.prototype.concat(...filePaths))
+    return Array.prototype.concat(...filePaths)
   }
 
   /**

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,8 +1,6 @@
 // Node imports
 const crypto = require('crypto')
 const fs = require('fs')
-// NPM imports
-const Bluebird = require('bluebird')
 
 const HASH_ALGORITHM = 'md5'
 const HASH_DIGEST_ENCODING = 'hex'
@@ -12,19 +10,19 @@ const HASH_DIGEST_ENCODING = 'hex'
 /**
  * Generate a hash of the supplied file
  * @param {string} filePath
- * @returns {Bluebird<Hash>}
+ * @returns {Promise.<Hash>}
  */
-function hashFromFile(filePath) {
+async function hashFromFile(filePath) {
   return hashFromStream(fs.createReadStream(filePath))
 }
 
 /**
  * Generate a hash of the supplied stream
  * @param {NodeJS.ReadableStream} readableStream
- * @returns {Bluebird<Hash>}
+ * @returns {Promise.<Hash>}
  */
-function hashFromStream(readableStream) {
-  return new Bluebird((resolve, reject) => {
+async function hashFromStream(readableStream) {
+  return new Promise((resolve, reject) => {
     const hashStream = crypto.createHash(HASH_ALGORITHM)
     readableStream.pipe(hashStream)
     .on('error', reject)

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -5,6 +5,8 @@ const zlib = require('zlib')
 // Lib imports
 const fileLib = require('./file')
 
+const DEFAULT_GZIP_OPTIONS = { level: 9 }
+
 /**
  * @param {string} filePath
  * @returns {Promise.<string>}
@@ -58,8 +60,18 @@ function stringToStream(data, encoding = 'utf8') {
   })
 }
 
+/**
+ * @param {NodeJS.ReadableStream} stream
+ * @returns {NodeJS.ReadableStream}
+ */
+function gzipStream(stream) {
+  const gzip = zlib.createGzip(DEFAULT_GZIP_OPTIONS)
+  return stream.pipe(gzip)
+}
+
 module.exports = {
   fileToString,
+  gzipStream,
   streamToString,
   stringToStream
 }

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -2,17 +2,15 @@
 const fs = require('fs')
 const stream = require('stream')
 const zlib = require('zlib')
-// NPM imports
-const Bluebird = require('bluebird')
 // Lib imports
 const fileLib = require('./file')
 
 /**
  * @param {string} filePath
- * @returns {Bluebird<string>}
+ * @returns {Promise.<string>}
  * @private
  */
-function fileToString(filePath) {
+async function fileToString(filePath) {
   const fileStream = fs.createReadStream(filePath)
   const readerStream = fileLib.isGzipped(filePath)
   ? fileStream.pipe(zlib.createGunzip())
@@ -23,10 +21,10 @@ function fileToString(filePath) {
 /**
  * @param {NodeJS.ReadableStream} readerStream
  * @param {BufferEncoding} [encoding]
- * @returns {Bluebird<string>}
+ * @returns {Promise.<string>}
  */
-function streamToString(readerStream, encoding = 'utf8') {
-  return new Bluebird((resolve, reject) => {
+async function streamToString(readerStream, encoding = 'utf8') {
+  return new Promise((resolve, reject) => {
     /** @type {Array.<Uint8Array>} */
     const chunks = []
     readerStream.on('data', (/** @type {Uint8Array} */ chunk) => {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,15 +1,12 @@
 // Node imports
 const fs = require('fs')
 const path = require('path')
-const zlib = require('zlib')
 // Lib imports
 const fileLib = require('./file')
 const hashLib = require('./hash')
 const streamLib = require('./stream')
 
 const { CONTENT_TYPE_CSS, CONTENT_TYPE_JS } = fileLib
-
-const DEFAULT_GZIP_OPTIONS = { level: 9 }
 
 const CSS_URL_REGEXP = /url\(\/([^)]+)\)/g
 const CSS_SOURCEMAP_REGEXP = /\/\*# sourceMappingURL=([^*]+)\*\/$/
@@ -95,7 +92,7 @@ async function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
     const transformedStream = streamLib.stringToStream(transformedData)
     // Re-compress the stream if the original file was gzipped
     return fileLib.isGzipped(filePath)
-    ? gzipStream(transformedStream)
+    ? streamLib.gzipStream(transformedStream)
     : transformedStream
   }
 
@@ -183,16 +180,6 @@ async function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
   }
 }
 
-/**
- * @param {NodeJS.ReadableStream} stream
- * @returns {NodeJS.ReadableStream}
- */
-function gzipStream(stream) {
-  const gzip = zlib.createGzip(DEFAULT_GZIP_OPTIONS)
-  return stream.pipe(gzip)
-}
-
 module.exports = {
-  gzipStream,
   replaceHashedFilenames
 }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -2,8 +2,6 @@
 const fs = require('fs')
 const path = require('path')
 const zlib = require('zlib')
-// NPM imports
-const Bluebird = require('bluebird')
 // Lib imports
 const fileLib = require('./file')
 const hashLib = require('./hash')
@@ -24,15 +22,7 @@ const JS_SOURCEMAP_REGEXP = /\/\/# sourceMappingURL=(.+)$/
  */
 
 /**
- * @typedef {Object} ReplaceHashedFilenamesOptions
- * @property {string} filePath
- * @property {string} relativeFileName
- * @property {S3SyncDigest} digest
- */
-
-/**
- * @typedef {Object} ReplaceHashedFilenamesResult
- * @property {boolean} transformed
+ * @typedef {Object} TransformedFileResult
  * @property {NodeJS.ReadableStream} stream
  * @property {string} [hash]
  */
@@ -44,11 +34,14 @@ const JS_SOURCEMAP_REGEXP = /\/\/# sourceMappingURL=(.+)$/
  */
 
 /**
- * @param {ReplaceHashedFilenamesOptions} options
- * @returns {Bluebird<ReplaceHashedFilenamesResult>}
+ * @param {Object} options
+ * @param {string} options.filePath
+ * @param {string} options.relativeFileName
+ * @param {S3SyncDigest} options.digest
+ * @returns {Promise.<TransformedFileResult>}
  * @public
  */
-function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
+async function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
   const relativeDirPath = path.dirname(relativeFileName)
   const contentType = fileLib.getContentType(filePath)
   if (contentType === CONTENT_TYPE_JS) {
@@ -57,14 +50,13 @@ function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
   if (contentType === CONTENT_TYPE_CSS) {
     return transformFile(replaceHashedFilenamesInCss)
   }
-  return Bluebird.resolve(originalFileResult())
+  return originalFileResult()
 
   /**
-   * @returns {ReplaceHashedFilenamesResult}
+   * @returns {TransformedFileResult}
    */
   function originalFileResult() {
     return {
-      transformed: false,
       stream: fs.createReadStream(filePath)
     }
   }
@@ -72,11 +64,10 @@ function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
   /**
    * @param {string} transformedData
    * @param {string} recalculatedHash
-   * @returns {ReplaceHashedFilenamesResult}
+   * @returns {TransformedFileResult}
    */
   function transformedFileResult(transformedData, recalculatedHash) {
     return {
-      transformed: true,
       stream: transformedDataToStream(transformedData),
       hash: recalculatedHash
     }
@@ -84,20 +75,16 @@ function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
 
   /**
    * @param {TransformFileCallback} transformCallback
-   * @returns {Bluebird<ReplaceHashedFilenamesResult>}
+   * @returns {Promise.<TransformedFileResult>}
    */
-  function transformFile(transformCallback) {
-    return streamLib.fileToString(filePath)
-    .then(originalData => {
-      const transformedData = transformCallback(originalData)
-      if (originalData === transformedData) {
-        return originalFileResult()
-      }
-      return recalculateHash(transformedData)
-      .then(recalculatedHash => {
-        return transformedFileResult(transformedData, recalculatedHash)
-      })
-    })
+  async function transformFile(transformCallback) {
+    const originalData = await streamLib.fileToString(filePath)
+    const transformedData = transformCallback(originalData)
+    if (originalData === transformedData) {
+      return originalFileResult()
+    }
+    const recalculatedHash = await recalculateHash(transformedData)
+    return transformedFileResult(transformedData, recalculatedHash)
   }
 
   /**
@@ -108,18 +95,18 @@ function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
     const transformedStream = streamLib.stringToStream(transformedData)
     // Re-compress the stream if the original file was gzipped
     return fileLib.isGzipped(filePath)
-    ? transformedStream.pipe(zlib.createGzip(DEFAULT_GZIP_OPTIONS))
+    ? gzipStream(transformedStream)
     : transformedStream
   }
 
   /**
    * @param {string} transformedData
-   * @returns {Bluebird<string>} recalculated hash of transformed file
+   * @returns {Promise.<string>} recalculated hash of transformed file
    */
-  function recalculateHash(transformedData) {
+  async function recalculateHash(transformedData) {
     if (!fileLib.isGzipped(filePath)) {
       // Fast-path to avoid unnecessary conversion to stream
-      return Bluebird.resolve(hashLib.hashFromString(transformedData))
+      return hashLib.hashFromString(transformedData)
     }
     const transformedStream = transformedDataToStream(transformedData)
     return hashLib.hashFromStream(transformedStream)
@@ -196,6 +183,16 @@ function replaceHashedFilenames({ filePath, relativeFileName, digest }) {
   }
 }
 
+/**
+ * @param {NodeJS.ReadableStream} stream
+ * @returns {NodeJS.ReadableStream}
+ */
+function gzipStream(stream) {
+  const gzip = zlib.createGzip(DEFAULT_GZIP_OPTIONS)
+  return stream.pipe(gzip)
+}
+
 module.exports = {
+  gzipStream,
   replaceHashedFilenames
 }


### PR DESCRIPTION
https://app.asana.com/0/703301881682354/1165405828201763/f

### Also:

* Refactor Promise usage to leverage async/await (https://github.com/mix/s3-asset-uploader/commit/2fbafb539614c40c87963674f25b81f67a96b827)
  * Minimize Bluebird usage
  * Normalize Bluebird types into native Promise