### PR TITLE
only pass in AWS credentials from config if they exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ const DEFAULT_GZIP_HEADERS = {
 /**
  * The configuration Object passed into the `S3Sync` constructor
  * @typedef {Object} S3SyncConfig
- * @property {string} key - your AWS access key ID
- * @property {string} secret - your AWS secret access key
+ * @property {string} [key] - your AWS access key ID
+ * @property {string} [secret] - your AWS secret access key
  * @property {AWS.S3.BucketName} bucket - the name of the destination AWS S3 bucket
  */
 
@@ -89,13 +89,14 @@ class S3Sync {
    * @constructor
    */
   constructor(config, options) {
-    this.client = new AWS.S3({})
+    let s3ClientConfiguration = {}
     if (config.key && config.secret) {
-      AWS.config.update({
+      s3ClientConfiguration = {
         accessKeyId: config.key,
         secretAccessKey: config.secret
-      })
+      }
     }
+    this.client = new AWS.S3(s3ClientConfiguration)
     this.bucket = config.bucket
     this.path = fs.realpathSync(options.path)
     this.ignorePaths = options.ignorePaths || []

--- a/index.js
+++ b/index.js
@@ -89,10 +89,13 @@ class S3Sync {
    * @constructor
    */
   constructor(config, options) {
-    this.client = new AWS.S3({
-      accessKeyId: config.key,
-      secretAccessKey: config.secret
-    })
+    this.client = new AWS.S3({})
+    if (config.key && config.secret) {
+      AWS.config.update({
+        accessKeyId: config.key,
+        secretAccessKey: config.secret
+      })
+    }
     this.bucket = config.bucket
     this.path = fs.realpathSync(options.path)
     this.ignorePaths = options.ignorePaths || []


### PR DESCRIPTION
this supports the ability of the AWS sdk to use EC2 IAM role credentials

ref: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-iam.html